### PR TITLE
stop monitor on disconnect

### DIFF
--- a/iHSV-Servo-Tool.py
+++ b/iHSV-Servo-Tool.py
@@ -314,6 +314,8 @@ class MainWindow(QMainWindow):
                 self.statusBar().showMessage("Device does not respond", 2000)
                 return
         else:
+            if (self.pbStartStopMonitor.text() == 'Stop Monitor'):
+                self.startStopMonitor()
             try:
                 self.servo.serial.close()
                 self.statusBar().showMessage("Port closed", 2000)


### PR DESCRIPTION
Hi Robert,

großartiges Programm! Hast du das Protokoll selber reverse-engineered oder hast du das von JMC? Mir haben sie nach meiner Anfrage nicht mehr geantwortet...
Ich habe auch gleich noch zwei Anfragen:
- Einstellungen der Servos in eine Textdatei (am liebsten tsv, nur persönliche Präferenz) speichern
- Möglichkeit das Quadrat des Pos-Errors über die Zeit zu integrieren während man (natürlich außerhalb von deinem Tool) ein Programm durchlaufen lässt. Damit könnte man verschiedene Einstellungen unter realistischen Bedingungen miteinander vergleichen.

Wenn's dir lieber ist mach ich für beide ein Issue auf, sollten beide recht schnell gehen. Ich habe noch nicht mit QT gearbeitet, daher (für die beiden) noch kein PR.

Zum PR: sollte selbsterklärend sein, ist mir beim rumprobieren aufgefallen.

Viele Grüße
Martin